### PR TITLE
feat: change swagger docs

### DIFF
--- a/components/routes/admin-routes.js
+++ b/components/routes/admin-routes.js
@@ -1,23 +1,15 @@
-const expressSwaggerGenerator = require('express-swagger-generator');
+const expressJSDocSwagger = require('express-jsdoc-swagger');
 
 module.exports = () => {
 	const start = async ({ manifest = {}, app, config }) => {
 		const { swaggerOptions } = config;
-		const expressSwagger = expressSwaggerGenerator(app);
-		const options = {
-			swaggerDefinition: {
-				...swaggerOptions.swaggerDefinition,
-			},
-			basedir: __dirname,
-			files: ['./**/**-routes.js'],
-		};
-		expressSwagger(options);
+		expressJSDocSwagger(app)(swaggerOptions);
 
 		/**
-		 * This endpoint serves the manifest
-		 * @route GET /__/manifest
-		 * @group Admin - Everything about admin routes
-		 * @returns 200 - Sucessful response
+		 * GET /__/manifest
+     * @summary This endpoint serves the manifest
+		 * @tags Admin - Everything about admin routes
+		 * @return {object} 200 - Sucessful response
 		*/
 		app.get('/__/manifest', (req, res) => res.json(manifest));
 

--- a/components/routes/admin-routes.js
+++ b/components/routes/admin-routes.js
@@ -7,7 +7,7 @@ module.exports = () => {
 
 		/**
 		 * GET /__/manifest
-     * @summary This endpoint serves the manifest
+		 * @summary This endpoint serves the manifest
 		 * @tags Admin - Everything about admin routes
 		 * @return {object} 200 - Sucessful response
 		*/

--- a/config/default.js
+++ b/config/default.js
@@ -6,25 +6,24 @@ module.exports = {
 	routes: {
 		admin: {
 			swaggerOptions: {
-				swaggerDefinition: {
-					info: {
-						description: 'Documentation for service-matteoaffinity',
-						title: 'service-matteoaffinity',
-						version: '1.0.0',
-					},
-					host: process.env.SERVICE_ENV || 'localhost:4000',
-					basePath: '/v1',
-					produces: ['application/json'],
-					schemes: ['http'],
-					securityDefinitions: {
-						JWT: {
-							type: 'apiKey',
-							in: 'header',
-							name: 'Authorization',
-							description: '',
-						},
+				info: {
+					description: 'Documentation for service-matteoaffinity',
+					title: 'service-matteoaffinity',
+					version: '1.0.0',
+					contact: {
+						name: 'Guidesmiths',
 					},
 				},
+				servers: [],
+				security: {
+					JWT: {
+						type: 'apiKey',
+						in: 'header',
+						name: 'Authorization',
+					},
+				},
+				baseDir: process.cwd(),
+				filesPattern: './**/**-routes.js',
 			},
 		},
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1069,11 +1069,11 @@
       }
     },
     "express-jsdoc-swagger": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/express-jsdoc-swagger/-/express-jsdoc-swagger-1.0.1.tgz",
-      "integrity": "sha512-PS6f9LoqxA82lcLXXfaFdrszwvcXybwGRhms1dcyYWdeubxVRmbn8efWHw6OSWGrBZZqsyVa9qppFK9JGUmO3Q==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/express-jsdoc-swagger/-/express-jsdoc-swagger-1.0.4.tgz",
+      "integrity": "sha512-+D04u9jnSyEytfr6/gsGQgHtf8NgDgE91BLkzSZgDG/qsTbzu9hxANUdShiIZt3Sexkd7g7O9lcKrMo1NT4xTA==",
       "requires": {
-        "chalk": "^4.0.0",
+        "chalk": "^4.1.0",
         "doctrine": "^3.0.0",
         "express": "^4.17.1",
         "glob": "^7.1.6",
@@ -3354,9 +3354,9 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "swagger-ui-dist": {
-      "version": "3.26.2",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.26.2.tgz",
-      "integrity": "sha512-cpR3A9uEs95gGQSaIXgiTpnetIifTF1u2a0fWrnVl+HyLpCdHVgOy7FGlVD1iVkts7AE5GOiGjA7VyDNiRaNgw=="
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.31.1.tgz",
+      "integrity": "sha512-+IuIxXX8grZcDVLaC12WCGy62iHJ2v8kTptU4H4EgY/ue6tKeMu/jzIAs+pLFOuYwfG4+VQ+CrC9UeHR9oNKBw=="
     },
     "swagger-ui-express": {
       "version": "4.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,11 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -161,6 +166,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -290,11 +296,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-    },
-    "call-me-maybe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
     },
     "caller-callsite": {
       "version": "2.0.0",
@@ -620,19 +621,11 @@
       "dev": true
     },
     "doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "doctrine-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/doctrine-file/-/doctrine-file-1.0.3.tgz",
-      "integrity": "sha512-OK37HbZtNmIMn84riibVXRmcEGUIf6BNfYMcbXg20ejP+LEsf4tnk8QfYy3EmQs4KzZFhTl3zwoKqVwARxpBgA==",
-      "requires": {
-        "doctrine": "^2.0.0"
       }
     },
     "dotenv": {
@@ -965,7 +958,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.0.1",
@@ -1074,19 +1068,50 @@
         "vary": "~1.1.2"
       }
     },
-    "express-swagger-generator": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/express-swagger-generator/-/express-swagger-generator-1.1.15.tgz",
-      "integrity": "sha512-dOqXj+amehXMyPxGnkHDdGDGSxQy5fBrZ74d3L7noLfGDC2b6pb+uziZ/QcBth/w6AwtxpUWlRI9K0hyoIQRvQ==",
+    "express-jsdoc-swagger": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/express-jsdoc-swagger/-/express-jsdoc-swagger-1.0.1.tgz",
+      "integrity": "sha512-PS6f9LoqxA82lcLXXfaFdrszwvcXybwGRhms1dcyYWdeubxVRmbn8efWHw6OSWGrBZZqsyVa9qppFK9JGUmO3Q==",
       "requires": {
-        "doctrine": "^2.0.0",
-        "doctrine-file": "^1.0.2",
-        "express-swaggerize-ui": "^1.0.3",
-        "glob": "^7.0.3",
-        "recursive-iterator": "^2.0.3",
-        "swagger-parser": "^5.0.5"
+        "chalk": "^4.0.0",
+        "doctrine": "^3.0.0",
+        "express": "^4.17.1",
+        "glob": "^7.1.6",
+        "merge": "^1.2.1",
+        "swagger-ui-express": "^4.1.4"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
         "glob": {
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -1099,15 +1124,20 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
-      }
-    },
-    "express-swaggerize-ui": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/express-swaggerize-ui/-/express-swaggerize-ui-1.1.0.tgz",
-      "integrity": "sha512-dDJuWV/GlISNYyKvFMa3EDr6sYzMgMrVRCt9o1kQxaIIKnmK1NJvaTzGbRIokIlGGHriIT6E2ztorRyRxLuOzA==",
-      "requires": {
-        "express": "^4.13.3"
       }
     },
     "extend": {
@@ -1272,11 +1302,6 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
-    },
-    "format-util": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
-      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
     },
     "formidable": {
       "version": "1.2.1",
@@ -1861,6 +1886,7 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1871,32 +1897,6 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
-    },
-    "json-schema-ref-parser": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-5.1.3.tgz",
-      "integrity": "sha512-CpDFlBwz/6la78hZxyB9FECVKGYjIIl3Ms3KLqFj99W7IIb7D00/RDgc++IGB4BBALl0QRhh5m4q5WNSopvLtQ==",
-      "requires": {
-        "call-me-maybe": "^1.0.1",
-        "debug": "^3.1.0",
-        "js-yaml": "^3.12.0",
-        "ono": "^4.0.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -1909,16 +1909,6 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
-    },
-    "jsonschema": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
-    },
-    "jsonschema-draft4": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/jsonschema-draft4/-/jsonschema-draft4-1.0.0.tgz",
-      "integrity": "sha1-8K8gBQVPDwrefqIRhhS2ncUS2GU="
     },
     "jsontoxml": {
       "version": "0.1.1",
@@ -1997,11 +1987,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
       "integrity": "sha1-ChG6Yx0OlcI8fy9Mu5ppLtF45wU="
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.isfunction": {
       "version": "3.0.9",
@@ -2470,24 +2455,6 @@
         "mimic-fn": "^2.1.0"
       }
     },
-    "ono": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
-      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
-      "requires": {
-        "format-util": "^1.0.3"
-      }
-    },
-    "openapi-schema-validation": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/openapi-schema-validation/-/openapi-schema-validation-0.4.2.tgz",
-      "integrity": "sha512-K8LqLpkUf2S04p2Nphq9L+3bGFh/kJypxIG2NVGKX0ffzT4NQI9HirhiY6Iurfej9lCu7y4Ndm4tv+lm86Ck7w==",
-      "requires": {
-        "jsonschema": "1.2.4",
-        "jsonschema-draft4": "^1.0.0",
-        "swagger-schema-official": "2.0.0-bab6bed"
-      }
-    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -2908,11 +2875,6 @@
         "resolve": "^1.1.6"
       }
     },
-    "recursive-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/recursive-iterator/-/recursive-iterator-2.0.3.tgz",
-      "integrity": "sha1-0ODSx+eoMQnXMJHPBD/FCeWnbcM="
-    },
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
@@ -3235,7 +3197,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sql-params-format": {
       "version": "2.0.0",
@@ -3390,45 +3353,18 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
-    "swagger-methods": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.8.tgz",
-      "integrity": "sha512-G6baCwuHA+C5jf4FNOrosE4XlmGsdjbOjdBK4yuiDDj/ro9uR4Srj3OR84oQMT8F3qKp00tYNv0YN730oTHPZA=="
+    "swagger-ui-dist": {
+      "version": "3.26.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.26.2.tgz",
+      "integrity": "sha512-cpR3A9uEs95gGQSaIXgiTpnetIifTF1u2a0fWrnVl+HyLpCdHVgOy7FGlVD1iVkts7AE5GOiGjA7VyDNiRaNgw=="
     },
-    "swagger-parser": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-5.0.6.tgz",
-      "integrity": "sha512-FdzCYFK11iGgrOpojlqUluU6SKThtzmu+5Get+6ValJR2TFwTnES1x4Fdfgy3C4/8VVXk4Va/WsqGlbyY/Os+A==",
+    "swagger-ui-express": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.4.tgz",
+      "integrity": "sha512-Ea96ecpC+Iq9GUqkeD/LFR32xSs8gYqmTW1gXCuKg81c26WV6ZC2FsBSPVExQP6WkyUuz5HEiR0sEv/HCC343g==",
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "debug": "^3.1.0",
-        "json-schema-ref-parser": "^5.1.3",
-        "ono": "^4.0.6",
-        "openapi-schema-validation": "^0.4.2",
-        "swagger-methods": "^1.0.4",
-        "swagger-schema-official": "2.0.0-bab6bed",
-        "z-schema": "^3.23.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
+        "swagger-ui-dist": "^3.18.1"
       }
-    },
-    "swagger-schema-official": {
-      "version": "2.0.0-bab6bed",
-      "resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
-      "integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
     },
     "systemic": {
       "version": "3.3.0",
@@ -3696,11 +3632,6 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
-    "validator": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
-      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
-    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -3758,18 +3689,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-    },
-    "z-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.25.1.tgz",
-      "integrity": "sha512-7tDlwhrBG+oYFdXNOjILSurpfQyuVgkRe3hB2q8TEssamDHB7BbLWYkYO98nTn0FibfdFroFKDjndbgufAgS/Q==",
-      "requires": {
-        "commander": "^2.7.1",
-        "core-js": "^2.5.7",
-        "lodash.get": "^4.0.0",
-        "lodash.isequal": "^4.0.0",
-        "validator": "^10.0.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"confabulous": "^1.1.0",
 		"debug": "^2.2.0",
 		"dotenv": "^8.2.0",
-		"express-swagger-generator": "^1.1.15",
+		"express-jsdoc-swagger": "^1.0.1",
 		"handy-postgres": "^1.1.1",
 		"hogan.js": "^3.0.2",
 		"make-manifest": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"confabulous": "^1.1.0",
 		"debug": "^2.2.0",
 		"dotenv": "^8.2.0",
-		"express-jsdoc-swagger": "^1.0.1",
+		"express-jsdoc-swagger": "^1.0.4",
 		"handy-postgres": "^1.1.1",
 		"hogan.js": "^3.0.2",
 		"make-manifest": "^1.0.1",


### PR DESCRIPTION
## What’s the focus of this PR
This PR adds swagger Docs using OpenAPI v3 specification instead of Swagger V2.

Using `express-jsdoc-swagger` instead of `express-swagger-generator` will look like this. This new dependency has full support for the new Open API specification.

<img width="1420" alt="Screen Shot 2020-06-15 at 18 53 58" src="https://user-images.githubusercontent.com/12685053/84686825-f6b24c00-af3c-11ea-9e2e-f4aacf4d68c3.png">


Before submitting this PR, I made sure:

- [x] The code builds clean without any errors or warnings
- [x] I'm using our guidelines
- [x] I've added unit tests if feasible
